### PR TITLE
Improve About Us responsiveness

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -41,10 +41,10 @@ const page = () => {
       </div>
       {/* banner end */}
       {/* about */}
-      <div className="mil-p-100-50">
+      <div className="mil-p-100-50 about-section">
         <div className="container">
           <div className="row flex-sm-row-reverse justify-content-between align-items-center">
-            <div className="col-lg-5 mil-mb-100">
+            <div className="col-lg-5 mil-mb-100 about-text">
               <div className="mil-suptitle mil-sm mil-accent mil-mb-30 mil-up">
                 About us
               </div>
@@ -60,8 +60,8 @@ const page = () => {
                 </Link>
               </div>
             </div>
-            <div className="col-lg-6 ">
-              <div className="">
+            <div className="col-lg-6">
+              <div className="about-lottie">
                 <LottieComponent source={About} width={600} height={600} />
               </div>
             </div>

--- a/components/Lottie.js
+++ b/components/Lottie.js
@@ -13,16 +13,18 @@ const LottieComponent = ({
 }) => {
   const { width: screenWidth } = useWindowSize();
 
-  // Adjust size based on screen width
-  const scale = width > screenWidth ? screenWidth / width : 1;
-  const adjustedWidth = width * scale;
-  const adjustedHeight = height * scale;
+  // Adjust container for small screens and keep aspect ratio
+  const containerMaxWidth = screenWidth
+    ? Math.min(width, Math.max(screenWidth - 40, 0))
+    : width;
 
   return (
     <div
       style={{
-        width: adjustedWidth,
-        height: adjustedHeight,
+        width: "100%",
+        maxWidth: containerMaxWidth,
+        margin: "0 auto",
+        aspectRatio: `${width}/${height}`,
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
@@ -33,7 +35,7 @@ const LottieComponent = ({
         animationData={source}
         loop={loop}
         autoplay={autoPlay}
-        style={{ width: adjustedWidth, height: adjustedHeight }}
+        style={{ width: "100%", height: "100%" }}
       />
     </div>
   );

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -894,14 +894,25 @@ space
   }
 }
 
-.mil-p-200-150 {
-  padding-top: 200px;
-  padding-bottom: 150px;
+  .mil-p-200-150 {
+    padding-top: 200px;
+    padding-bottom: 150px;
+  }
+  @media (max-width: 1200px) {
+    .mil-p-200-150 {
+      padding-top: 100px;
+      padding-bottom: 50px;
+    }
+  }
+
+.mil-p-100-50 {
+  padding-top: 100px;
+  padding-bottom: 50px;
 }
 @media (max-width: 1200px) {
-  .mil-p-200-150 {
-    padding-top: 100px;
-    padding-bottom: 50px;
+  .mil-p-100-50 {
+    padding-top: 70px;
+    padding-bottom: 40px;
   }
 }
 
@@ -3273,10 +3284,10 @@ footer .mil-footer-list li {
   list-style-type: none;
   margin-bottom: 10px;
 }
-footer .mil-footer-bottom {
-  padding-top: 60px;
-  border-top: solid 1px rgba(137, 141, 150, 0.3);
-  display: -webkit-box;
+  footer .mil-footer-bottom {
+    padding-top: 60px;
+    border-top: solid 1px rgba(137, 141, 150, 0.3);
+    display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
   -webkit-box-pack: justify;
@@ -3289,5 +3300,24 @@ footer .mil-footer-bottom {
     -webkit-box-direction: normal;
         -ms-flex-direction: column;
             flex-direction: column;
+  }
+}
+
+/* custom about section adjustments */
+.about-section .about-lottie {
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
+}
+.about-section .about-text {
+  margin-bottom: 50px;
+}
+@media (max-width: 768px) {
+  .about-section {
+    padding-top: 70px;
+    padding-bottom: 50px;
+  }
+  .about-section .about-text {
+    margin-bottom: 40px;
   }
 }


### PR DESCRIPTION
## Summary
- tweak About Us layout on `page.js`
- update `LottieComponent` to scale responsively
- define missing padding utility and new About styles

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68526fbf5df88326a01ce002ca9454a1