### PR TITLE
Ensure dark theme text styles apply

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -30,6 +30,19 @@ html.theme-dark .mil-wrapper {
   background-color: #212121;
 }
 
+html.theme-dark h1,
+html.theme-dark h2,
+html.theme-dark h3,
+html.theme-dark h4,
+html.theme-dark h5,
+html.theme-dark h6 {
+  color: #FFFFFF !important;
+}
+
+html.theme-dark .mil-dark {
+  color: #FFFFFF !important;
+}
+
 .mil-theme-toggle {
   background: none;
   border: none;


### PR DESCRIPTION
## Summary
- fix dark mode heading and text color definitions

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685278c4b46083268bb35e8e6444c422