### PR TITLE
Add scroll driven Lottie animation on service page

### DIFF
--- a/app/services/page.js
+++ b/app/services/page.js
@@ -4,6 +4,7 @@ import PageBanner from "@/components/PageBanner";
 import MoorkLayout from "@/layout/MoorkLayout";
 
 import tube from "@/public/lottie/tube.json";
+import ScrollLottie from "@/components/ScrollLottie";
 
 const page = () => {
   return (
@@ -18,10 +19,10 @@ const page = () => {
 
       {/* banner end */}
       {/* services */}
-      <div className="mil-p-200-100">
+      <div className="mil-p-200-100 services-section">
         <div className="container">
-          <div className="row">
-            <div className="col-lg-12">
+          <div className="row align-items-center">
+            <div className="col-lg-6 order-lg-1 order-2">
               <h3 className="mil-mb-30 mil-up">
                 Fire Protection and Detection systems
               </h3>
@@ -145,6 +146,14 @@ const page = () => {
                   </div>
                 </li>
               </ul>
+            </div>
+            <div className="col-lg-6 order-lg-2 order-1 mb-60 mb-lg-0">
+              <ScrollLottie
+                animationData={tube}
+                width={920}
+                height={1080}
+                className="scroll-lottie"
+              />
             </div>
           </div>
         </div>

--- a/components/ScrollLottie.js
+++ b/components/ScrollLottie.js
@@ -1,0 +1,61 @@
+"use client";
+import { useEffect, useRef, useState } from "react";
+import Lottie from "lottie-react";
+
+const ScrollLottie = ({
+  animationData,
+  width = 920,
+  height = 1080,
+  className = "",
+}) => {
+  const containerRef = useRef(null);
+  const lottieRef = useRef();
+  const [scrollProgress, setScrollProgress] = useState(0);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      if (!containerRef.current) return;
+      const rect = containerRef.current.getBoundingClientRect();
+      const windowHeight = window.innerHeight || document.documentElement.clientHeight;
+      const total = rect.height + windowHeight;
+      const visible = Math.min(Math.max(windowHeight - rect.top, 0), total);
+      const progress = visible / total;
+      setScrollProgress(progress);
+    };
+
+    window.addEventListener("scroll", handleScroll);
+    handleScroll();
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  useEffect(() => {
+    if (lottieRef.current) {
+      const totalFrames = lottieRef.current.getDuration(true);
+      const frame = Math.floor(scrollProgress * (totalFrames - 1));
+      lottieRef.current.goToAndStop(frame, true);
+    }
+  }, [scrollProgress]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={className}
+      style={{
+        width: "100%",
+        maxWidth: width,
+        margin: "0 auto",
+        aspectRatio: `${width}/${height}`,
+      }}
+    >
+      <Lottie
+        lottieRef={lottieRef}
+        animationData={animationData}
+        autoplay={false}
+        loop={false}
+        style={{ width: "100%", height: "100%" }}
+      />
+    </div>
+  );
+};
+
+export default ScrollLottie;

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -3333,6 +3333,18 @@ footer .mil-footer-bottom {
   margin-left: auto;
   margin-right: auto;
 }
+
+/* custom services section adjustments */
+.services-section .scroll-lottie {
+  max-width: 920px;
+  margin-left: auto;
+  margin-right: auto;
+}
+@media (max-width: 991px) {
+  .services-section .scroll-lottie {
+    margin-bottom: 40px;
+  }
+}
 .about-section .about-text {
   margin-bottom: 50px;
 }


### PR DESCRIPTION
## Summary
- create `ScrollLottie` component to sync frames with scroll position
- use the new component on the services page with `tube.json`
- style service section for responsiveness

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686236df6674832687ed62f83345c6a1