### PR TITLE
Add email sending from contact form

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,3 @@
+SMTP_USER=your_email@example.com
+SMTP_PASS=your_email_password
+NOTIFY_EMAIL=your_notification_email@example.com

--- a/app/api/contact/route.js
+++ b/app/api/contact/route.js
@@ -1,0 +1,49 @@
+import nodemailer from 'nodemailer';
+import { NextResponse } from 'next/server';
+
+export async function POST(request) {
+  try {
+    const { name, email, phone, subject, message } = await request.json();
+
+    const transporter = nodemailer.createTransport({
+      service: 'gmail',
+      auth: {
+        user: process.env.SMTP_USER,
+        pass: process.env.SMTP_PASS,
+      },
+    });
+
+    const notifyMail = {
+      from: process.env.SMTP_USER,
+      to: process.env.NOTIFY_EMAIL || process.env.SMTP_USER,
+      subject: `New contact from ${name}`,
+      html: `
+        <h3>Contact Details</h3>
+        <p><strong>Name:</strong> ${name}</p>
+        <p><strong>Email:</strong> ${email}</p>
+        <p><strong>Phone:</strong> ${phone}</p>
+        <p><strong>Subject:</strong> ${subject}</p>
+        <p><strong>Message:</strong><br/>${message}</p>
+      `,
+    };
+
+    const userMail = {
+      from: process.env.SMTP_USER,
+      to: email,
+      subject: 'We received your message',
+      html: `
+        <p>Hi ${name},</p>
+        <p>Thank you for contacting us. We will review your enquiry and get back to you shortly.</p>
+        <p>-- SDS Civil & Fire Security Engineering</p>
+      `,
+    };
+
+    await transporter.sendMail(notifyMail);
+    await transporter.sendMail(userMail);
+
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ success: false }, { status: 500 });
+  }
+}

--- a/app/contact/page.js
+++ b/app/contact/page.js
@@ -1,7 +1,42 @@
+"use client";
 import CallToAction from "@/components/CallToAction";
 import PageBanner from "@/components/PageBanner";
 import MoorkLayout from "@/layout/MoorkLayout";
+import { useState } from "react";
+
 const page = () => {
+  const [form, setForm] = useState({
+    name: "",
+    email: "",
+    phone: "",
+    subject: "",
+    message: "",
+  });
+  const [status, setStatus] = useState(null);
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setStatus("loading");
+    try {
+      const res = await fetch("/api/contact", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(form),
+      });
+      if (res.ok) {
+        setStatus("success");
+        setForm({ name: "", email: "", phone: "", subject: "", message: "" });
+      } else {
+        setStatus("error");
+      }
+    } catch (err) {
+      setStatus("error");
+    }
+  };
   return (
     <MoorkLayout>
       <PageBanner
@@ -63,12 +98,15 @@ const page = () => {
               </h2>
             </div>
             <div className="col-lg-8 mil-mb-100">
-              <form>
+              <form onSubmit={handleSubmit}>
                 <div className="row">
                   <div className="col-lg-6">
                     <input
                       type="text"
                       className="mil-input mil-mb-30 mil-up"
+                      name="name"
+                      value={form.name}
+                      onChange={handleChange}
                       placeholder="Name"
                     />
                   </div>
@@ -76,6 +114,9 @@ const page = () => {
                     <input
                       type="email"
                       className="mil-input mil-mb-30 mil-up"
+                      name="email"
+                      value={form.email}
+                      onChange={handleChange}
                       placeholder="Email"
                     />
                   </div>
@@ -84,18 +125,25 @@ const page = () => {
                   <input
                     type="number"
                     className="mil-input mil-mb-30 mil-up"
+                    name="phone"
+                    value={form.phone}
+                    onChange={handleChange}
                     placeholder="Phone"
                   />
                   <input
                     type="text"
                     className="mil-input mil-mb-30 mil-up"
+                    name="subject"
+                    value={form.subject}
+                    onChange={handleChange}
                     placeholder="Subject"
                   />
                   <textarea
-                    name="Message"
+                    name="message"
                     placeholder="Message"
                     className="mil-mb-30 mil-up"
-                    defaultValue={""}
+                    value={form.message}
+                    onChange={handleChange}
                   />
                   <div className="mil-checkbox-frame mil-mb-30 mil-up">
                     <div className="mil-checkbox">
@@ -114,6 +162,12 @@ const page = () => {
                       Submit
                     </button>
                   </div>
+                  {status === "success" && (
+                    <p className="mil-mt-20">Thank you for your message.</p>
+                  )}
+                  {status === "error" && (
+                    <p className="mil-mt-20">Something went wrong. Please try again.</p>
+                  )}
                 </div>
               </form>
             </div>

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "react-use": "^17.6.0",
     "sanity": "^3.92.0",
     "styled-components": "^6.1.19",
-    "swiper": "^11.1.1"
+    "swiper": "^11.1.1",
+    "nodemailer": "^6.9.11"
   },
   "devDependencies": {
     "@types/babel__generator": "^7.27.0",


### PR DESCRIPTION
## Summary
- add Nodemailer dependency
- add API route to send contact emails
- wire up form on the Contact page
- document required email environment variables

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6870e1c949b88326b3f473365cb995e7